### PR TITLE
Remove leftover pack and lib files

### DIFF
--- a/lib/Abuilder.mldylib
+++ b/lib/Abuilder.mldylib
@@ -1,4 +1,0 @@
-# OASIS_START
-# DO NOT EDIT (digest: 59927f90f7d47b6660ac4173b5c6b5d7)
-Abuilder
-# OASIS_STOP

--- a/lib/Abuilder.mllib
+++ b/lib/Abuilder.mllib
@@ -1,4 +1,0 @@
-# OASIS_START
-# DO NOT EDIT (digest: 59927f90f7d47b6660ac4173b5c6b5d7)
-Abuilder
-# OASIS_STOP

--- a/lib/Abuilder.mlpack
+++ b/lib/Abuilder.mlpack
@@ -1,4 +1,0 @@
-# OASIS_START
-# DO NOT EDIT (digest: 0cbc6611f5540bd0809a388dc95a615b)
-Test
-# OASIS_STOP

--- a/lib/abuilder.mldylib
+++ b/lib/abuilder.mldylib
@@ -1,4 +1,0 @@
-# OASIS_START
-# DO NOT EDIT (digest: 59927f90f7d47b6660ac4173b5c6b5d7)
-Abuilder
-# OASIS_STOP

--- a/lib/abuilder.mllib
+++ b/lib/abuilder.mllib
@@ -1,4 +1,0 @@
-# OASIS_START
-# DO NOT EDIT (digest: 59927f90f7d47b6660ac4173b5c6b5d7)
-Abuilder
-# OASIS_STOP

--- a/lib/abuilder.mlpack
+++ b/lib/abuilder.mlpack
@@ -1,4 +1,0 @@
-# OASIS_START
-# DO NOT EDIT (digest: 59927f90f7d47b6660ac4173b5c6b5d7)
-Abuilder
-# OASIS_STOP


### PR DESCRIPTION
I think this is causing your circular build issue. In particular, at some point you used "abuilder" as the name of the library in your `_oasis` file and then changed it. You've also turned on `-pack` so all the modules are automatically packed into a top-level module. The files `lib/abuilder.mlpack` and `lib/abuilder.mllib` then refer to the `Abuilder` module which they help define (and ignore the actual `Abuilder` implementation in `abuilder.ml` and `abuilder.mli`.
